### PR TITLE
Rf kill server

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -32,6 +32,12 @@ const books = [
     author: 'Michael Crichton',
     rating: 4
   },
+  {
+    title: 'The Plague',
+    author: 'Albert Camus',
+    rating: 10
+  },
+
 ];
 
 // Resolvers define the technique for fetching the types defined in the

--- a/engine/package.json
+++ b/engine/package.json
@@ -7,7 +7,8 @@
     "dev": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "DOCKER_BUILDKIT=1 docker build --tag olange/arcade-engine .",
-    "server": "docker run --detach --name arcade-engine --publish 4000:4000 olange/arcade-engine"
+    "server": "docker run --detach --name arcade-engine --publish 4000:4000 olange/arcade-engine",
+    "kill": "docker rm -f $(docker ps -a --filter 'name=arcade-engine' -q)"
   },
   "keywords": [
     "arcade",

--- a/engine/package.json
+++ b/engine/package.json
@@ -4,11 +4,11 @@
   "description": "Distributed Arcade Game Engine",
   "main": "index.js",
   "scripts": {
-    "dev": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "DOCKER_BUILDKIT=1 docker build --tag olange/arcade-engine .",
-    "server": "docker run --detach --name arcade-engine --publish 4000:4000 olange/arcade-engine",
-    "kill": "docker rm -f $(docker ps -a --filter 'name=arcade-engine' -q)"
+    "start": "node index.js",
+    "test":  "echo \"Error: no test specified\" && exit 1",
+    "docker:build": "DOCKER_BUILDKIT=1 docker build --tag olange/arcade-engine .",
+    "docker:start": "docker run --detach --name arcade-engine --publish 4000:4000 olange/arcade-engine",
+    "docker:stop":  "docker rm -f $(docker ps -a --filter 'name=arcade-engine' -q)"
   },
   "keywords": [
     "arcade",


### PR DESCRIPTION
@olange **Is there a better way to handle this problem: `npm run server` fails if the container name is already in use**

My problem:
```
engine % npm run server
...
docker: Error response from daemon: Conflict. The container name "/arcade-engine" is already in use by container ... 
You have to remove (or rename) that container to be able to reuse that name.
```
My solution:
```
+    "server": "docker run --detach --name arcade-engine --publish 4000:4000 olange/arcade-engine",
+    "kill": "docker rm -f $(docker ps -a --filter 'name=arcade-engine' -q)"
```
Is there a better way to handle this situation?
