### PR TITLE
‹Hexgrid› module for webapp & monorepo layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,9 +190,9 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "node_modules/has": {
@@ -255,9 +255,9 @@
       "dev": true
     },
     "node_modules/is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -303,11 +303,12 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "dependencies": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       },
       "engines": {
@@ -535,12 +536,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       },
       "funding": {
@@ -616,14 +617,14 @@
       "dev": true
     },
     "node_modules/string.prototype.padend": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.1.tgz",
-      "integrity": "sha512-eCzTASPnoCr5Ht+Vn1YXgm8SB015hHKgEIMu9Nr9bQmLhRBxKRfmzSj/IQsxDFc8JInJDDFA0qXwK+xxI7wDkg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
+        "es-abstract": "^1.18.0-next.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -633,12 +634,12 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "funding": {
@@ -646,12 +647,12 @@
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "funding": {
@@ -847,9 +848,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -858,9 +859,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "has": {
@@ -897,9 +898,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true
     },
     "is-core-module": {
@@ -924,11 +925,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
     },
@@ -1094,12 +1096,12 @@
       }
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -1163,33 +1165,33 @@
       "dev": true
     },
     "string.prototype.padend": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.1.tgz",
-      "integrity": "sha512-eCzTASPnoCr5Ht+Vn1YXgm8SB015hHKgEIMu9Nr9bQmLhRBxKRfmzSj/IQsxDFc8JInJDDFA0qXwK+xxI7wDkg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
+        "es-abstract": "^1.18.0-next.2"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "start": "run-p start:webapp",
     "start:webapp": "npm --prefix webapp run start",
     "start:firebase": "firebase serve --only hosting",
-    "build": "run-s build:*",
+    "build": "run-s build:packages:* build:*",
+    "build:packages:hexgrid": "npm --prefix packages/hexgrid run build",
     "build:webapp": "npm --prefix webapp run build",
     "deploy": "firebase deploy --only hosting"
   },

--- a/packages/hexgrid/.gitignore
+++ b/packages/hexgrid/.gitignore
@@ -1,0 +1,5 @@
+# Dependency directories
+node_modules/
+
+# Snowpack build generated files
+dist/

--- a/packages/hexgrid/.npmignore
+++ b/packages/hexgrid/.npmignore
@@ -1,0 +1,3 @@
+dist/modules/
+src/
+snowpack.config.js

--- a/packages/hexgrid/LICENSE
+++ b/packages/hexgrid/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Olivier Lange
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/hexgrid/README.md
+++ b/packages/hexgrid/README.md
@@ -1,0 +1,19 @@
+# Hexgrid
+
+‹Hexgrid› implementation from [Red Blob Games](https://www.redblobgames.com/grids/hexagons/implementation.html), packaged as an ES module.
+
+## Install
+
+`npm install`
+
+## Build
+
+`npm run build`
+
+## Usage
+
+```javascript
+import { Layout } from '@gongfuio/hexgrid';
+
+const layout = Layout.pointy;
+```

--- a/packages/hexgrid/package-lock.json
+++ b/packages/hexgrid/package-lock.json
@@ -1,0 +1,405 @@
+{
+  "name": "@gongfuio/hexgrid",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@gongfuio/hexgrid",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "prettier": "^2.2.1",
+        "snowpack": "^3.0.13"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.7"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-2.0.0.tgz",
+      "integrity": "sha1-AezONxpx6F8VoXF354YwR+c9vn0=",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.1.0",
+        "pify": "^2.3.0",
+        "untildify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.8.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.51.tgz",
+      "integrity": "sha512-MVIom8fgL1+B6iGqWtrG7QJ1gqd64BycxounlsX1kR/IcIITaSlTo7gghKpg4a+bnxkpo0dwcikuvk4MVSA9ww==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
+      "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/snowpack": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.13.tgz",
+      "integrity": "sha512-USTcpfJ68rbuFvUygw+3n9qS1CC/tGsr/JNVc6FNk0ZRfGBE4OmB+Mmk5nWtdxi546GeCr/GvveJenYLen/WpA==",
+      "dev": true,
+      "dependencies": {
+        "default-browser-id": "^2.0.0",
+        "esbuild": "^0.8.7",
+        "open": "^7.0.4",
+        "resolve": "^1.20.0",
+        "rollup": "^2.34.0"
+      },
+      "bin": {
+        "snowpack": "index.bin.js",
+        "sp": "index.bin.js"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.2.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true
+    },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.7"
+      }
+    },
+    "default-browser-id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-2.0.0.tgz",
+      "integrity": "sha1-AezONxpx6F8VoXF354YwR+c9vn0=",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.1.0",
+        "pify": "^2.3.0",
+        "untildify": "^2.0.0"
+      }
+    },
+    "esbuild": {
+      "version": "0.8.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.51.tgz",
+      "integrity": "sha512-MVIom8fgL1+B6iGqWtrG7QJ1gqd64BycxounlsX1kR/IcIITaSlTo7gghKpg4a+bnxkpo0dwcikuvk4MVSA9ww==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
+      "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "snowpack": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.13.tgz",
+      "integrity": "sha512-USTcpfJ68rbuFvUygw+3n9qS1CC/tGsr/JNVc6FNk0ZRfGBE4OmB+Mmk5nWtdxi546GeCr/GvveJenYLen/WpA==",
+      "dev": true,
+      "requires": {
+        "default-browser-id": "^2.0.0",
+        "esbuild": "^0.8.7",
+        "fsevents": "^2.2.0",
+        "open": "^7.0.4",
+        "resolve": "^1.20.0",
+        "rollup": "^2.34.0"
+      }
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    }
+  }
+}

--- a/packages/hexgrid/package.json
+++ b/packages/hexgrid/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@gongfuio/hexgrid",
+  "version": "0.1.0",
+  "description": "‹Hexgrid› implementation from Red Blob Games (https://www.redblobgames.com/grids/hexagons/implementation.html) packaged as an ES module",
+  "author": "Amit Patel",
+  "contributors": [
+    "Olivier Lange",
+    "Rudi Farkas"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [
+    "arcade",
+    "game",
+    "hexagrid"
+  ],
+  "module": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "postinstall": "npm dedupe",
+    "prepare": "npm run build",
+    "build": "snowpack build",
+    "format": "prettier --write \"src/**/*.js\"",
+    "lint": "prettier --check \"src/**/*.js\"",
+    "test": "echo \"This package does not include a test runner.\" && exit 1"
+  },
+  "devDependencies": {
+    "prettier": "^2.2.1",
+    "snowpack": "^3.0.13"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "homepage": "https://github.com/olange/arcade#readme",
+  "bugs": {
+    "url": "https://github.com/olange/arcade/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/olange/arcade.git",
+    "directory": "packages/hexgrid"
+  }
+}

--- a/packages/hexgrid/snowpack.config.js
+++ b/packages/hexgrid/snowpack.config.js
@@ -1,0 +1,13 @@
+// Snowpack Configuration File
+// See all supported options: https://www.snowpack.dev/reference/configuration
+
+/** @type {import("snowpack").SnowpackUserConfig } */
+module.exports = {
+  mount: {
+    "src": { url: "/" }
+  },
+  plugins: [],
+  packageOptions: {},
+  buildOptions: { out: "dist", metaUrlPath: "modules", sourcemap: true },
+  optimize: { minify: true, treeshake: true }
+};

--- a/packages/hexgrid/src/index.js
+++ b/packages/hexgrid/src/index.js
@@ -1,0 +1,332 @@
+// Generated code -- CC0 -- No Rights Reserved -- http://www.redblobgames.com/grids/hexagons/
+export class Point {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+export class Hex {
+    constructor(q, r, s) {
+        this.q = q;
+        this.r = r;
+        this.s = s;
+        if (Math.round(q + r + s) !== 0)
+            throw "q + r + s must be 0";
+    }
+    add(b) {
+        return new Hex(this.q + b.q, this.r + b.r, this.s + b.s);
+    }
+    subtract(b) {
+        return new Hex(this.q - b.q, this.r - b.r, this.s - b.s);
+    }
+    scale(k) {
+        return new Hex(this.q * k, this.r * k, this.s * k);
+    }
+    rotateLeft() {
+        return new Hex(-this.s, -this.q, -this.r);
+    }
+    rotateRight() {
+        return new Hex(-this.r, -this.s, -this.q);
+    }
+    static direction(direction) {
+        return Hex.directions[direction];
+    }
+    neighbor(direction) {
+        return this.add(Hex.direction(direction));
+    }
+    diagonalNeighbor(direction) {
+        return this.add(Hex.diagonals[direction]);
+    }
+    len() {
+        return (Math.abs(this.q) + Math.abs(this.r) + Math.abs(this.s)) / 2;
+    }
+    distance(b) {
+        return this.subtract(b).len();
+    }
+    round() {
+        var qi = Math.round(this.q);
+        var ri = Math.round(this.r);
+        var si = Math.round(this.s);
+        var q_diff = Math.abs(qi - this.q);
+        var r_diff = Math.abs(ri - this.r);
+        var s_diff = Math.abs(si - this.s);
+        if (q_diff > r_diff && q_diff > s_diff) {
+            qi = -ri - si;
+        }
+        else if (r_diff > s_diff) {
+            ri = -qi - si;
+        }
+        else {
+            si = -qi - ri;
+        }
+        return new Hex(qi, ri, si);
+    }
+    lerp(b, t) {
+        return new Hex(this.q * (1.0 - t) + b.q * t, this.r * (1.0 - t) + b.r * t, this.s * (1.0 - t) + b.s * t);
+    }
+    linedraw(b) {
+        var N = this.distance(b);
+        var a_nudge = new Hex(this.q + 1e-06, this.r + 1e-06, this.s - 2e-06);
+        var b_nudge = new Hex(b.q + 1e-06, b.r + 1e-06, b.s - 2e-06);
+        var results = [];
+        var step = 1.0 / Math.max(N, 1);
+        for (var i = 0; i <= N; i++) {
+            results.push(a_nudge.lerp(b_nudge, step * i).round());
+        }
+        return results;
+    }
+}
+Hex.directions = [new Hex(1, 0, -1), new Hex(1, -1, 0), new Hex(0, -1, 1), new Hex(-1, 0, 1), new Hex(-1, 1, 0), new Hex(0, 1, -1)];
+Hex.diagonals = [new Hex(2, -1, -1), new Hex(1, -2, 1), new Hex(-1, -1, 2), new Hex(-2, 1, 1), new Hex(-1, 2, -1), new Hex(1, 1, -2)];
+export class OffsetCoord {
+    constructor(col, row) {
+        this.col = col;
+        this.row = row;
+    }
+    static qoffsetFromCube(offset, h) {
+        var col = h.q;
+        var row = h.r + (h.q + offset * (h.q & 1)) / 2;
+        if (offset !== OffsetCoord.EVEN && offset !== OffsetCoord.ODD) {
+            throw "offset must be EVEN (+1) or ODD (-1)";
+        }
+        return new OffsetCoord(col, row);
+    }
+    static qoffsetToCube(offset, h) {
+        var q = h.col;
+        var r = h.row - (h.col + offset * (h.col & 1)) / 2;
+        var s = -q - r;
+        if (offset !== OffsetCoord.EVEN && offset !== OffsetCoord.ODD) {
+            throw "offset must be EVEN (+1) or ODD (-1)";
+        }
+        return new Hex(q, r, s);
+    }
+    static roffsetFromCube(offset, h) {
+        var col = h.q + (h.r + offset * (h.r & 1)) / 2;
+        var row = h.r;
+        if (offset !== OffsetCoord.EVEN && offset !== OffsetCoord.ODD) {
+            throw "offset must be EVEN (+1) or ODD (-1)";
+        }
+        return new OffsetCoord(col, row);
+    }
+    static roffsetToCube(offset, h) {
+        var q = h.col - (h.row + offset * (h.row & 1)) / 2;
+        var r = h.row;
+        var s = -q - r;
+        if (offset !== OffsetCoord.EVEN && offset !== OffsetCoord.ODD) {
+            throw "offset must be EVEN (+1) or ODD (-1)";
+        }
+        return new Hex(q, r, s);
+    }
+}
+OffsetCoord.EVEN = 1;
+OffsetCoord.ODD = -1;
+export class DoubledCoord {
+    constructor(col, row) {
+        this.col = col;
+        this.row = row;
+    }
+    static qdoubledFromCube(h) {
+        var col = h.q;
+        var row = 2 * h.r + h.q;
+        return new DoubledCoord(col, row);
+    }
+    qdoubledToCube() {
+        var q = this.col;
+        var r = (this.row - this.col) / 2;
+        var s = -q - r;
+        return new Hex(q, r, s);
+    }
+    static rdoubledFromCube(h) {
+        var col = 2 * h.q + h.r;
+        var row = h.r;
+        return new DoubledCoord(col, row);
+    }
+    rdoubledToCube() {
+        var q = (this.col - this.row) / 2;
+        var r = this.row;
+        var s = -q - r;
+        return new Hex(q, r, s);
+    }
+}
+export class Orientation {
+    constructor(f0, f1, f2, f3, b0, b1, b2, b3, start_angle) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.b0 = b0;
+        this.b1 = b1;
+        this.b2 = b2;
+        this.b3 = b3;
+        this.start_angle = start_angle;
+    }
+}
+export class Layout {
+    constructor(orientation, size, origin) {
+        this.orientation = orientation;
+        this.size = size;
+        this.origin = origin;
+    }
+    hexToPixel(h) {
+        var M = this.orientation;
+        var size = this.size;
+        var origin = this.origin;
+        var x = (M.f0 * h.q + M.f1 * h.r) * size.x;
+        var y = (M.f2 * h.q + M.f3 * h.r) * size.y;
+        return new Point(x + origin.x, y + origin.y);
+    }
+    pixelToHex(p) {
+        var M = this.orientation;
+        var size = this.size;
+        var origin = this.origin;
+        var pt = new Point((p.x - origin.x) / size.x, (p.y - origin.y) / size.y);
+        var q = M.b0 * pt.x + M.b1 * pt.y;
+        var r = M.b2 * pt.x + M.b3 * pt.y;
+        return new Hex(q, r, -q - r);
+    }
+    hexCornerOffset(corner) {
+        var M = this.orientation;
+        var size = this.size;
+        var angle = 2.0 * Math.PI * (M.start_angle - corner) / 6.0;
+        return new Point(size.x * Math.cos(angle), size.y * Math.sin(angle));
+    }
+    polygonCorners(h) {
+        var corners = [];
+        var center = this.hexToPixel(h);
+        for (var i = 0; i < 6; i++) {
+            var offset = this.hexCornerOffset(i);
+            corners.push(new Point(center.x + offset.x, center.y + offset.y));
+        }
+        return corners;
+    }
+}
+Layout.pointy = new Orientation(Math.sqrt(3.0), Math.sqrt(3.0) / 2.0, 0.0, 3.0 / 2.0, Math.sqrt(3.0) / 3.0, -1.0 / 3.0, 0.0, 2.0 / 3.0, 0.5);
+Layout.flat = new Orientation(3.0 / 2.0, 0.0, Math.sqrt(3.0) / 2.0, Math.sqrt(3.0), 2.0 / 3.0, 0.0, -1.0 / 3.0, Math.sqrt(3.0) / 3.0, 0.0);
+class Tests {
+    constructor() { }
+    static equalHex(name, a, b) {
+        if (!(a.q === b.q && a.s === b.s && a.r === b.r)) {
+            complain(name);
+        }
+    }
+    static equalOffsetcoord(name, a, b) {
+        if (!(a.col === b.col && a.row === b.row)) {
+            complain(name);
+        }
+    }
+    static equalDoubledcoord(name, a, b) {
+        if (!(a.col === b.col && a.row === b.row)) {
+            complain(name);
+        }
+    }
+    static equalInt(name, a, b) {
+        if (!(a === b)) {
+            complain(name);
+        }
+    }
+    static equalHexArray(name, a, b) {
+        Tests.equalInt(name, a.length, b.length);
+        for (var i = 0; i < a.length; i++) {
+            Tests.equalHex(name, a[i], b[i]);
+        }
+    }
+    static testHexArithmetic() {
+        Tests.equalHex("hex_add", new Hex(4, -10, 6), new Hex(1, -3, 2).add(new Hex(3, -7, 4)));
+        Tests.equalHex("hex_subtract", new Hex(-2, 4, -2), new Hex(1, -3, 2).subtract(new Hex(3, -7, 4)));
+    }
+    static testHexDirection() {
+        Tests.equalHex("hex_direction", new Hex(0, -1, 1), Hex.direction(2));
+    }
+    static testHexNeighbor() {
+        Tests.equalHex("hex_neighbor", new Hex(1, -3, 2), new Hex(1, -2, 1).neighbor(2));
+    }
+    static testHexDiagonal() {
+        Tests.equalHex("hex_diagonal", new Hex(-1, -1, 2), new Hex(1, -2, 1).diagonalNeighbor(3));
+    }
+    static testHexDistance() {
+        Tests.equalInt("hex_distance", 7, new Hex(3, -7, 4).distance(new Hex(0, 0, 0)));
+    }
+    static testHexRotateRight() {
+        Tests.equalHex("hex_rotate_right", new Hex(1, -3, 2).rotateRight(), new Hex(3, -2, -1));
+    }
+    static testHexRotateLeft() {
+        Tests.equalHex("hex_rotate_left", new Hex(1, -3, 2).rotateLeft(), new Hex(-2, -1, 3));
+    }
+    static testHexRound() {
+        var a = new Hex(0.0, 0.0, 0.0);
+        var b = new Hex(1.0, -1.0, 0.0);
+        var c = new Hex(0.0, -1.0, 1.0);
+        Tests.equalHex("hex_round 1", new Hex(5, -10, 5), new Hex(0.0, 0.0, 0.0).lerp(new Hex(10.0, -20.0, 10.0), 0.5).round());
+        Tests.equalHex("hex_round 2", a.round(), a.lerp(b, 0.499).round());
+        Tests.equalHex("hex_round 3", b.round(), a.lerp(b, 0.501).round());
+        Tests.equalHex("hex_round 4", a.round(), new Hex(a.q * 0.4 + b.q * 0.3 + c.q * 0.3, a.r * 0.4 + b.r * 0.3 + c.r * 0.3, a.s * 0.4 + b.s * 0.3 + c.s * 0.3).round());
+        Tests.equalHex("hex_round 5", c.round(), new Hex(a.q * 0.3 + b.q * 0.3 + c.q * 0.4, a.r * 0.3 + b.r * 0.3 + c.r * 0.4, a.s * 0.3 + b.s * 0.3 + c.s * 0.4).round());
+    }
+    static testHexLinedraw() {
+        Tests.equalHexArray("hex_linedraw", [new Hex(0, 0, 0), new Hex(0, -1, 1), new Hex(0, -2, 2), new Hex(1, -3, 2), new Hex(1, -4, 3), new Hex(1, -5, 4)], new Hex(0, 0, 0).linedraw(new Hex(1, -5, 4)));
+    }
+    static testLayout() {
+        var h = new Hex(3, 4, -7);
+        var flat = new Layout(Layout.flat, new Point(10.0, 15.0), new Point(35.0, 71.0));
+        Tests.equalHex("layout", h, flat.pixelToHex(flat.hexToPixel(h)).round());
+        var pointy = new Layout(Layout.pointy, new Point(10.0, 15.0), new Point(35.0, 71.0));
+        Tests.equalHex("layout", h, pointy.pixelToHex(pointy.hexToPixel(h)).round());
+    }
+    static testOffsetRoundtrip() {
+        var a = new Hex(3, 4, -7);
+        var b = new OffsetCoord(1, -3);
+        Tests.equalHex("conversion_roundtrip even-q", a, OffsetCoord.qoffsetToCube(OffsetCoord.EVEN, OffsetCoord.qoffsetFromCube(OffsetCoord.EVEN, a)));
+        Tests.equalOffsetcoord("conversion_roundtrip even-q", b, OffsetCoord.qoffsetFromCube(OffsetCoord.EVEN, OffsetCoord.qoffsetToCube(OffsetCoord.EVEN, b)));
+        Tests.equalHex("conversion_roundtrip odd-q", a, OffsetCoord.qoffsetToCube(OffsetCoord.ODD, OffsetCoord.qoffsetFromCube(OffsetCoord.ODD, a)));
+        Tests.equalOffsetcoord("conversion_roundtrip odd-q", b, OffsetCoord.qoffsetFromCube(OffsetCoord.ODD, OffsetCoord.qoffsetToCube(OffsetCoord.ODD, b)));
+        Tests.equalHex("conversion_roundtrip even-r", a, OffsetCoord.roffsetToCube(OffsetCoord.EVEN, OffsetCoord.roffsetFromCube(OffsetCoord.EVEN, a)));
+        Tests.equalOffsetcoord("conversion_roundtrip even-r", b, OffsetCoord.roffsetFromCube(OffsetCoord.EVEN, OffsetCoord.roffsetToCube(OffsetCoord.EVEN, b)));
+        Tests.equalHex("conversion_roundtrip odd-r", a, OffsetCoord.roffsetToCube(OffsetCoord.ODD, OffsetCoord.roffsetFromCube(OffsetCoord.ODD, a)));
+        Tests.equalOffsetcoord("conversion_roundtrip odd-r", b, OffsetCoord.roffsetFromCube(OffsetCoord.ODD, OffsetCoord.roffsetToCube(OffsetCoord.ODD, b)));
+    }
+    static testOffsetFromCube() {
+        Tests.equalOffsetcoord("offset_from_cube even-q", new OffsetCoord(1, 3), OffsetCoord.qoffsetFromCube(OffsetCoord.EVEN, new Hex(1, 2, -3)));
+        Tests.equalOffsetcoord("offset_from_cube odd-q", new OffsetCoord(1, 2), OffsetCoord.qoffsetFromCube(OffsetCoord.ODD, new Hex(1, 2, -3)));
+    }
+    static testOffsetToCube() {
+        Tests.equalHex("offset_to_cube even-", new Hex(1, 2, -3), OffsetCoord.qoffsetToCube(OffsetCoord.EVEN, new OffsetCoord(1, 3)));
+        Tests.equalHex("offset_to_cube odd-q", new Hex(1, 2, -3), OffsetCoord.qoffsetToCube(OffsetCoord.ODD, new OffsetCoord(1, 2)));
+    }
+    static testDoubledRoundtrip() {
+        var a = new Hex(3, 4, -7);
+        var b = new DoubledCoord(1, -3);
+        Tests.equalHex("conversion_roundtrip doubled-q", a, DoubledCoord.qdoubledFromCube(a).qdoubledToCube());
+        Tests.equalDoubledcoord("conversion_roundtrip doubled-q", b, DoubledCoord.qdoubledFromCube(b.qdoubledToCube()));
+        Tests.equalHex("conversion_roundtrip doubled-r", a, DoubledCoord.rdoubledFromCube(a).rdoubledToCube());
+        Tests.equalDoubledcoord("conversion_roundtrip doubled-r", b, DoubledCoord.rdoubledFromCube(b.rdoubledToCube()));
+    }
+    static testDoubledFromCube() {
+        Tests.equalDoubledcoord("doubled_from_cube doubled-q", new DoubledCoord(1, 5), DoubledCoord.qdoubledFromCube(new Hex(1, 2, -3)));
+        Tests.equalDoubledcoord("doubled_from_cube doubled-r", new DoubledCoord(4, 2), DoubledCoord.rdoubledFromCube(new Hex(1, 2, -3)));
+    }
+    static testDoubledToCube() {
+        Tests.equalHex("doubled_to_cube doubled-q", new Hex(1, 2, -3), new DoubledCoord(1, 5).qdoubledToCube());
+        Tests.equalHex("doubled_to_cube doubled-r", new Hex(1, 2, -3), new DoubledCoord(4, 2).rdoubledToCube());
+    }
+    static testAll() {
+        Tests.testHexArithmetic();
+        Tests.testHexDirection();
+        Tests.testHexNeighbor();
+        Tests.testHexDiagonal();
+        Tests.testHexDistance();
+        Tests.testHexRotateRight();
+        Tests.testHexRotateLeft();
+        Tests.testHexRound();
+        Tests.testHexLinedraw();
+        Tests.testLayout();
+        Tests.testOffsetRoundtrip();
+        Tests.testOffsetFromCube();
+        Tests.testOffsetToCube();
+        Tests.testDoubledRoundtrip();
+        Tests.testDoubledFromCube();
+        Tests.testDoubledToCube();
+    }
+}
+// Tests
+function complain(name) { console.log("FAIL", name); }
+Tests.testAll();

--- a/webapp/.npmignore
+++ b/webapp/.npmignore
@@ -1,2 +1,5 @@
-.build
-build
+components/
+static/
+.prettierrc
+babel.config.json
+snowpack.config.js

--- a/webapp/components/app-game.js
+++ b/webapp/components/app-game.js
@@ -1,11 +1,12 @@
 import { LitElement, html, css } from 'lit-element';
 import { customElement, internalProperty, query } from 'lit-element';
-import * as PIXI from 'pixi.js'
+import * as PIXI from 'pixi.js';
 
 @customElement('app-game')
 export class AppGame extends LitElement {
 
-  @internalProperty({type: Object}) app;
+  @internalProperty({type: Object})
+  app;
 
   @internalProperty({type: Object})
   static pixiAppOptions = {
@@ -15,7 +16,8 @@ export class AppGame extends LitElement {
     resolution: 2,
   }
 
-  @query('div#container') containerEl;
+  @query('div#container')
+  containerEl;
 
   static get styles() {
     return css`

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9,51 +9,75 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "workspaces": [
+        "../packages/*"
+      ],
       "dependencies": {
+        "@gongfuio/hexgrid": "^0.1.0",
         "firebase": "^8.2.4",
         "lit-element": "^2.4.0",
         "pixi.js": "^5.3.7"
       },
       "devDependencies": {
-        "@babel/plugin-proposal-class-properties": "^7.12.1",
-        "@babel/plugin-proposal-decorators": "^7.12.12",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
         "@snowpack/plugin-babel": "^2.1.6",
         "prettier": "^2.2.1",
-        "snowpack": "^3.0.11"
+        "snowpack": "^3.0.13"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../packages/hexgrid": {
+      "name": "@gongfuio/hexgrid",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "prettier": "^2.2.1",
+        "snowpack": "^3.0.13"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.12.13"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.13.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
+      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "dev": true
+    },
     "node_modules/@babel/core": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
-      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
+      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.10",
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.10",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.0",
+        "@babel/parser": "^7.13.0",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "^5.4.1",
+        "semver": "7.0.0",
         "source-map": "^0.5.0"
       },
       "engines": {
@@ -65,130 +89,145 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
+      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.11",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
-      "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
+      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-member-expression-to-functions": "^7.12.1",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.10.4"
+        "@babel/compat-data": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.0.tgz",
+      "integrity": "sha512-twwzhthM4/+6o9766AW2ZBHpIHPSGrPGk1+WfHiu13u/lBnggXGNYCpeAyVfNwGDKfkhEDp+WOD/xafoJ2iLjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-split-export-declaration": "^7.12.13"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
-      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.7"
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.5"
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-simple-access": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "lodash": "^4.17.19"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
-      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
       "dev": true
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
-      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.7",
-        "@babel/helper-optimise-call-expression": "^7.12.10",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.11"
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -197,32 +236,38 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
     "node_modules/@babel/helpers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
+      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -232,76 +277,76 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
-      "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
+      "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.12.tgz",
-      "integrity": "sha512-fhkE9lJYpw2mjHelBpM2zCbaA11aov2GJs7q4cFaXNrWx0H3bW58H9Esy2rdtYOghFBEYUDRIpvlgi+ZD+AvvQ==",
+      "version": "7.13.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.5.tgz",
+      "integrity": "sha512-i0GDfVNuoapwiheevUOuSW67mInqJ8qw7uWfpjNVeHMn143kXblEy/bmL9AdZ/0yf/4BMQeWXezK0tQIvNPqag==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-decorators": "^7.12.1"
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-decorators": "^7.12.13"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
-      "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz",
+      "integrity": "sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.12.11",
-        "@babel/generator": "^7.12.11",
-        "@babel/helper-function-name": "^7.12.11",
-        "@babel/helper-split-export-declaration": "^7.12.11",
-        "@babel/parser": "^7.12.11",
-        "@babel/types": "^7.12.12",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -310,13 +355,13 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.4.tgz",
+      "integrity": "sha512-Lhnk5pXeDKoPf1b2cggWQaqCtNq+jn6IkhHMIo+7VztVt3i8ovnGuhAn/0hLC+XxvVWJ9q6CXIoGStkwvecDoA==",
       "dependencies": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -332,12 +377,12 @@
       "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
-      "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.15.tgz",
+      "integrity": "sha512-VfULP09cci4xk+iAU6CB2CUNU/vbpAOoUleDdspXFphV9Yw36anb8RjaHGcN1DRR7LNb7vznNJXHk8FJhC8VWQ==",
       "dependencies": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "dom-storage": "2.1.0",
@@ -351,11 +396,11 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "node_modules/@firebase/auth": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.2.tgz",
-      "integrity": "sha512-68TlDL0yh3kF8PiCzI8m8RWd/bf/xCLUsdz1NZ2Dwea0sp6e2WAhu0sem1GfhwuEwL+Ns4jCdX7qbe/OQlkVEA==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.4.tgz",
+      "integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
       "dependencies": {
-        "@firebase/auth-types": "0.10.1"
+        "@firebase/auth-types": "0.10.2"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
@@ -371,31 +416,31 @@
       }
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
+      "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "0.x"
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.2.0.tgz",
+      "integrity": "sha512-QJJxMEzLRMWjujPBrrS32BScg1wmdY/dZWR8nAEzyC8WKQsNevYR9ZKLbBYxaN0umH9yf5C40kwmy+gI8jStPw==",
       "dependencies": {
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.0.tgz",
-      "integrity": "sha512-j9NgRCsoahvAtQ8LPxMidGsiwsklbtUlDOQ6MhU6/Hk9DVYtEnVT3qSe42xOwBGDfMe191b1B2HsiEOsglWgag==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.4.tgz",
+      "integrity": "sha512-Fw2bA4OyxAMqLy8xtoZKlUAuDWjjH/z4AInRTAzHxgegXDbu0UK+VM0pmY44RuM2cmnVY4aW6xLXAdDKTY1aJQ==",
       "dependencies": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
+        "@firebase/component": "0.2.0",
+        "@firebase/database-types": "0.7.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "faye-websocket": "0.11.3",
@@ -403,19 +448,19 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.0.tgz",
+      "integrity": "sha512-FduQmPpUUOHgbOt7/vWlC1ntSLMEqqYessdQ/ODd7RFWm53iVa0T1mpIDtNwqd8gW3k7cajjSjcLjfQGtvLGDg==",
       "dependencies": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.3.tgz",
-      "integrity": "sha512-+No0hcaJ7hUYD/Vyv8xvEAnIqUQHJAFF5alL3clfyqmYa7bKtffjnZs2Pvm0fEIQ+LK4ovo2be2NmwK4iV0q5g==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.7.tgz",
+      "integrity": "sha512-sh+aX6udS8a+rwmlJO4zJwvoMC1D2x1CiPvj0nFYWhILRKWvztk/bOA3lT2FWcHY4kr/7x+CnqfwtiOSaufdNQ==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/firestore-types": "2.1.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
@@ -442,11 +487,11 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.2.tgz",
+      "integrity": "sha512-f+NxRd0k5RBPZUPj8lykeNMku8TpJTgZaRd3T6cXb8HbmSg/VY7uxQSGOXe11X2gSv/TvcwTQttViFzRMDs7CQ==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
@@ -463,11 +508,11 @@
       "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
     },
     "node_modules/@firebase/installations": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.20.tgz",
+      "integrity": "sha512-ddUPZQKHWJzqg3g11hxHIPhp3oMEmsPo0GSxtp9Xd2VLRU64MFNAAt5PiBbq1K92ukZVoNh6Ki6J6+hJEQcGQw==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/installations-types": "0.3.4",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -492,12 +537,12 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.4.tgz",
+      "integrity": "sha512-xIZ1vHnOcHAaj+H/gS8tu3QolR9up+fyTfgVLEFbZRsbAiLuIvuaoJwTHLAUTs/nJF6GtEGscRD4Jx/aFmEJRw==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/messaging-types": "0.5.0",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -517,12 +562,12 @@
       }
     },
     "node_modules/@firebase/performance": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
-      "integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.6.tgz",
+      "integrity": "sha512-fy9YPYnvePFxme7euyi8B658gF8JUQhAB1qv6hVw+HqjVZQIANhwM9AUBi9+5jikD7gD1CnU7EjREvoy8MJiAw==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
         "@firebase/util": "0.3.4",
@@ -549,12 +594,12 @@
       }
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.31.tgz",
+      "integrity": "sha512-QWjDsrLSqQnq/YTb3TSOJtIv7z2GXB7mTiwXE43NxYmsOX2z8KBlBBEHf9TcWk+90MKUTFfurDgYJN4rlIOxPg==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
         "@firebase/util": "0.3.4",
@@ -571,11 +616,11 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.3.tgz",
+      "integrity": "sha512-53IIt6Z3BltPBPmvxF/RGlvW8nBl4wI9GMR52CjRAIj438tPNxbpIvkLB956VVB9gfZhDcPIKxg7hNtC7hXrkA==",
       "dependencies": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/storage-types": "0.3.13",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -607,12 +652,16 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
       "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
     },
+    "node_modules/@gongfuio/hexgrid": {
+      "resolved": "../packages/hexgrid",
+      "link": true
+    },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.5.tgz",
-      "integrity": "sha512-CBCNwedw8McnEBq9jvoiJikws16WN0OiHFejQPovY71XkFWSiIqgvydYiDwpvIYDJmhPQ7qZNzW9BPndhXbx1Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
+      "integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
       "dependencies": {
-        "@types/node": "^12.12.47",
+        "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
         "semver": "^6.2.0"
       },
@@ -641,40 +690,40 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.7.tgz",
-      "integrity": "sha512-104qzGZWnA/cQUH48jTiCXKGqOCfOqZAHmVg1z0p5l5tnzVX5zUQDBJxt4AAIPguZZe1YkniealwO1WGz0yBgA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.8.tgz",
+      "integrity": "sha512-DBkUUPIDfaw1hXFLTOsmZ401JSyu286rS2UB79ClxvVtDfGI7pR+Hgq1PuNeoQSiO9Db32W4grvuxYTulO2jkQ==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.7.tgz",
-      "integrity": "sha512-xlXxMGiGGmOA154SyltOQ2ZfPEtErzXl8GOxXJJJBxmIfvCQa+Y6iO5jf4q7yNbpSbrfaeIrYUnNbJAViiACzg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.8.tgz",
+      "integrity": "sha512-eekP/tIPlERZOiWOCVKgOCc66JoAHDP7yT9DBw2LtCKswvP83iwN0PX5YR/u6Z05kUW5y8t4bigfLqEqc4uChw==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.7.tgz",
-      "integrity": "sha512-MBcgIM/mSqonFezkCI9080IqNlc0wb8S9QJ5otBdseOWUQa/ua2jF7Jd1sCBGmi0IzS9/NOHFXzZVTdS7AC7Ow=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.8.tgz",
+      "integrity": "sha512-vTkgBgiox2pLj2ZK/X37O6rFjsLic6CYa+rSCCMo8lCwipG/dgizYoAVIsmZy30tFgg1xYzI6qOw3MSVXupp8Q=="
     },
     "node_modules/@pixi/core": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.7.tgz",
-      "integrity": "sha512-WBhU2f5aJSVVaFP55FFBFKjKlRf5fYGxgA/U3kD4yD4Y3d3d6V3MIZv+o0VX+kBs1Eq7ePZqEv2smDrlzzMEjQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.8.tgz",
+      "integrity": "sha512-mbl7//UbNaIZJbS8R8g5o6cHAMW7xaJWW/dNazSJ9057Fpq5g3e3E2rreNTEILfC29cxm2sXDmgK5a9agoqJaA==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/runner": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/runner": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       },
       "funding": {
         "type": "opencollective",
@@ -682,306 +731,306 @@
       }
     },
     "node_modules/@pixi/display": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.7.tgz",
-      "integrity": "sha512-ma1JyLe5vaEgmaOR+anvj5YOKqT9OEWnboIe7NVmwGF1CZ7JFnB12rsRulHUsSaFG9bP5xjvroAZjFg/WvyGLw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.8.tgz",
+      "integrity": "sha512-ch7g63ox3iow/NEGbrArLfUMJVLVF+FpdFAp72uEweIzlcyzOQV6AcQTHtiRy4+tM6LdlcLSJXJISqGKt2R0Dg==",
       "dependencies": {
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/extract": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.7.tgz",
-      "integrity": "sha512-xQ5hYFIdxQTjNWwtwsjIK0DjbGLlUl92rIj5yvNJFiJvRjZ8IfvtIaM5uwjhiY2U9q3fDLFgb8EiNfmdDc78xQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.8.tgz",
+      "integrity": "sha512-z09D+5qmGQilbBXhR3xlZCixkTb6+1bSo6jGsbQxpu3xaF0ogh1HB76SJ2Wi1vwba9Q/PMb6RlawdEAg+sRFMg==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.7.tgz",
-      "integrity": "sha512-jkvbzmSCIPjCJMFNUocAxsZ7Cq3ssFwXnmXNYKYhJy01LxiyO/JbVDAxAD7Chyn5jbKsI21OV3UQaIJhFpXw7Q==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.8.tgz",
+      "integrity": "sha512-4vOmuWDLBiMbdQ2S3PmxzrzpPOrlzZVZ8iPEkQrBCYZ4dIuZY7NaV+9tneIK66dDfVI6OA8Ai304LH22nhC81Q==",
       "dependencies": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.7.tgz",
-      "integrity": "sha512-xM+Zz2i2UCmY7oHBPlGaN2ImhCY4l/V8NFc8FNSUIHm8NXHJ4/VCQpXp9BFTjY1+GZExFLkqB8kIYEddGVFiLA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.8.tgz",
+      "integrity": "sha512-biNqbfFIDbvOJJ+NiE9G0XojnuMQqtbcaDIiOScRoY3o3yCMjjcUxUMYrZ4xnTGGtEH23OKGUTZVf53qTQ4wiw==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/settings": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/settings": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.7.tgz",
-      "integrity": "sha512-Z12cxoHx9uMh3CZ0PLVRzsaFHHF/CfU3J83KI9k+Bg/DFOh/J/5EToCd44jYJbMKp3nvXcO1EJyZ3wwC/IsyfQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.8.tgz",
+      "integrity": "sha512-0Ag08uPKVoHWQSAIhS27Bs/b50NVMZ+3fUdNg9jgyrRthD/Uc2ljfkIJRa95Mj31YJBS15Giu4BGfefpe1i3zw==",
       "dependencies": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.7.tgz",
-      "integrity": "sha512-akMVkAHqliQujveiJ5KBMuwh/JVGN37NQsD8n1XbDDSe6SKjpX0kaq2Bh2Xu9pPj3+Jhofy0sI65q2M8qs2Uog==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.8.tgz",
+      "integrity": "sha512-OQYBK3oOId8VZV7KRYYdt196EYsG0cjAmQQT7P3/IETLIP6Mba+Bd/GtyxGEIBHcb7R5DebuvN4sVQtNgkRKlw==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.7.tgz",
-      "integrity": "sha512-NJpVcbOCUVYUDGqxvh7Jp/+arWEnLKgI/7Qf8VEYv0aQslqE8ZtFSAX7JfP+iGfFWXlkMe6AKspesYhUrIpRKg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.8.tgz",
+      "integrity": "sha512-eOfrp46AEjkAM1U+6k9Ga/5ezEwr1+7yGS3VijZBHntZTYKFhmGGOXrQxxL4KuslrfTV/smAflEr22U+A2H98A==",
       "dependencies": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.7.tgz",
-      "integrity": "sha512-P0mVQR2J7GHujVcq0iiuD2/1yvmue7orpppa5iuNHoOMT+vZpO0hdCKTg5vm5ZcWnHrOwtvv8zYngnT9rLdCtw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.8.tgz",
+      "integrity": "sha512-+MOz3GpB9XpH7d0B/HAz8zOp164UMKnE64Q9QI094X4KjXWj24RKZea8xFcOaOy9xKi57qqyo+3pLwqFB8ffsw==",
       "dependencies": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.7.tgz",
-      "integrity": "sha512-+6+bT/AC29a1Hw5XDxsH1UqBsXSqcna7wNTTrBQ02owotIJtyRc6w48f5qxzhxycumyVCR87IV5tAtdwX3xhag==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.8.tgz",
+      "integrity": "sha512-auqwS6ZnDlNoerddLCoMpEzgq0o09WHH7XxwfTK75hJwBaFX1RO/nasfvCx2wAtWZxAYCaABfR8WnWZfrsBSqA==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.7.tgz",
-      "integrity": "sha512-B+5suog6fo8tJclTIO1Nn0HikyXQ9OWQGmTiYUnDVDriX5dGujh79RpcL51HFQ/2Gs2Gt0rl3AfP9OsCLe7VPA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.8.tgz",
+      "integrity": "sha512-i9KS9TNVK/PEwyjZH2iqui9xroy0R48u/QL4Q8+VQpwbeDlz+WlPWoW5R7rpUwtHd9H6mLWpGR3sdWOmS7fMsA==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.7.tgz",
-      "integrity": "sha512-zwWgvhUz7l5Z3me5gT1XbJzmj4bnz176PnawoUdlRxNARnMW3Rsk7Egzu8atWhJUL+MWEv+t8KkyHRXG39q5FA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.8.tgz",
+      "integrity": "sha512-0M2e/gkBBqJW695wz9DcsYN7IY992FKqb9uOEhFFjCn2bkK9WsR6M/JBvTlTk4LOvEg81b1/J51bkucpXWx1Cg==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/utils": "5.3.7",
+        "@pixi/core": "5.3.8",
+        "@pixi/utils": "5.3.8",
         "resource-loader": "^3.0.1"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.7.tgz",
-      "integrity": "sha512-WnjUwX7rkxR36F0xknpsNd9BsfQosV0BbyFE0Il88IURBM3Tu9X4tC7RGJDgWU+aXw23HgHu0j+MWJrCVCM2fA=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.8.tgz",
+      "integrity": "sha512-MZekzC9W391KU2NyzbRHrgYfjPKguzU5cRLbaEw9dgDabLh3/Yzob1KVg8dngIITPbi5yBmoX7zh7ZHEA1NRPQ=="
     },
     "node_modules/@pixi/mesh": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.7.tgz",
-      "integrity": "sha512-7K5Ba3+t0rBAfZeuQi7nem0DgVH9GNhRvZ8HYbhPs5XVI7yZZhUN4HpUMy7gYEnz8EbXqwUz20X4ham/0O9WsQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.8.tgz",
+      "integrity": "sha512-/CQdTypiLgSZqKx9z89cJlLQ8/FaUrc8M3HjmL8Vy5F320ERCR1YLDc6gOzyohK71wDxkUud5VbNz5woQVSBxw==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.7.tgz",
-      "integrity": "sha512-txVo2yk935gLgvlwO/ODUuz0wHUZtc9AK0sOQbbD9rh1TUdZ9OYrRvqshItLC34EimmAfgOsyzT78zeUTaP1OA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.8.tgz",
+      "integrity": "sha512-+lHcmvslKsmlixiJW87/t5diRy7p+tvqQbXMG4/3Vzv3dBEGq453hMIknlLr2xLGyzBtboCHObzwKfeE4tvHTw==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.7.tgz",
-      "integrity": "sha512-UEP1PVEEqgWs8vUx/GvOiQ4r130NDLQoD9i5YA1i5BGml2UmNyrFlIh8N9hVAPiIpTIpECkU6nLakP7t6fm9zA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.8.tgz",
+      "integrity": "sha512-Y4z3yvMldRUU99I+FBOl+j+TCq7CXN2ysNED/vMD2YpfilS2/8dQcAqRNEOBXCdSixd6+QHBuc0+PWR6M7irKg==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.7.tgz",
-      "integrity": "sha512-KiWirq5HpLKrAsShdZx0+RwNwY6nO5cM+Wqq59n11xTgvUoNULiptZRePQR5rOIsLIcwNtro/2LWPj1UzbJHbg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.8.tgz",
+      "integrity": "sha512-6Z4C2SucwC1w2xa260VxU+uIkP8FhwnZWDfY0rxyxecWxvkM7ULsIU9szoUYUJvLJnpxRi4Xb6rXNPxXyzis9Q==",
       "dependencies": {
-        "@pixi/display": "5.3.7"
+        "@pixi/display": "5.3.8"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.7.tgz",
-      "integrity": "sha512-OIXi+m611GVH1dVAc5YdiMC55Bbjf0JmesiB+6/gMzrjKxW/YDAA5ZRVri75hmRedHA8LPflf+i0pO10mrGP8g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.8.tgz",
+      "integrity": "sha512-o2ZKmTxDvoibGBZ8LP3qJZ3cHe7L447qsuHPPLYOPmA5hqG49YchwmKMwV6tn96C8yDECaVn429Hu5hZEI7UlA==",
       "dependencies": {
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7"
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8"
       }
     },
     "node_modules/@pixi/particles": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.7.tgz",
-      "integrity": "sha512-mEnBljvBVbKuUJVZ0oH9dP/k7qsHEHUlvfBQgLOSkd6viHlx3PoSPKOYm35+I6fAylkV0Xm9+j5v/IESuip2RQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.8.tgz",
+      "integrity": "sha512-XAehJJ9SsLwlZF1Qkkir0ejPZ0YgCg8MbxzmrxBUbhH1NyHJLFm+K2S7Bp12FdR/hZwTENF7GMGVRH+o86u3hw==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.7.tgz",
-      "integrity": "sha512-qU23xdb/e4Qvze0TWVy4fNZ0nlABIEZmuLu5nI9SpgfIYtjd2tZo7ngCXU5mZHxW1/xvkAMJEHCsSszotzF9xQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.8.tgz",
+      "integrity": "sha512-AIXfAjYD7dfP2C+TX3482YterwGE876amqmk6EzMZCI3vvsvDJUGT/Dx6lSOU5zbcUbJ9t3Ybz81xQYpaEhv/Q==",
       "dependencies": {
         "es6-promise-polyfill": "^1.2.0",
         "object-assign": "^4.1.1"
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.7.tgz",
-      "integrity": "sha512-saU+o202vA3U2HVMYvh5aB2RJmP4hR//J22QuRfGen/ukM5mApOroJ445Id2+kSvis0M+UeFUKfBGWDzitr19Q==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.8.tgz",
+      "integrity": "sha512-DbYxQdziypsdQJaRKwdmODkIy2mQHETEFlVWou0XwVy+WB8VBlSnHZ57cVEY8l6Z0hJ93Vo4K6j5qIRi9MRjJA==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/graphics": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/ticker": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/graphics": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/ticker": "5.3.8"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.7.tgz",
-      "integrity": "sha512-kt5apNb21HAvpBaDaPRs33k2O0VzrKe13w4we8iftCpXX8w68ErAY1lH68vmtDNrxnlHg4M9nRgEoMeiHlo2RA=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.8.tgz",
+      "integrity": "sha512-6Y9v9OHd5FFv6s0M4AGHnG3qvLiTBM5T5RnlEqMNMsqH6CWSDq0mNJA5HQD65q5ViK8HM6MYPm2nwwkYq5AICQ=="
     },
     "node_modules/@pixi/settings": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.7.tgz",
-      "integrity": "sha512-g6AoRSGWxU34gtKSQwX2AMQoLUv86L/5iIXRsqo+X4bfUSCenTci1X7ueVrSIbo39dxh6IOpriZF2Yk3TeHG5w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.8.tgz",
+      "integrity": "sha512-/NSd9v6+IbG3GjzIoNwy7rgPg6kwwWy54pcaiM3Wv3zjkwhkVySK4m3h892Wa2z5lFvrHEH9zewGJwEpUH/FMA==",
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.7.tgz",
-      "integrity": "sha512-Bjl+NOOvigEzUsm1cDr1KmBUpPSWO8pDXpUPTi+v2N75gwRfTycmj5f2TU0QmMW3Gc6sv0CB0AkL7dkMPwPb8g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.8.tgz",
+      "integrity": "sha512-r+WeX5cti3VKu6U+hZeSiY4UC8912FjNU7M5bA/gev9CfUKv3fNwKYshPfzOkTPua8dFwI1U6tplYu5rSPMBmw==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.7.tgz",
-      "integrity": "sha512-CSXTSwH/UUcTe5637AD35OCETQO+tDkmlr6e1/eIyUlgOsPkbjo+l134feLZtZudiPHTPyb/YAYIlgPfVr7MGw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.8.tgz",
+      "integrity": "sha512-zLnzmCJJ++Hyyy1LPh5Lt4icPuy8C+vL59yVj3nAYzqq/G26rFuHELexB0iwKBPE9yQYuaUQhFgOPgW4vFqLAw==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/ticker": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/ticker": "5.3.8"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.7.tgz",
-      "integrity": "sha512-0BMLQGniJF1HvfyrJVe5jC8ayBpTh19dAHJIQWGp8zxxFh/WHjR1b32BN74rDjxQQSjZjV8vBNio8J3W+yDttw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.8.tgz",
+      "integrity": "sha512-SvCAvajihsaNx/xX4s6waEqPLVkI5W86h31kpoqdPj3zXhoLbpZh6t2TWbcRJmgjM1GvBNy14gWtelBq8UF7Mg==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.7.tgz",
-      "integrity": "sha512-K1Befbrq3LDbFtnLmbk54QQ/YRk2Mgd+2iOkZx5KsS2pTh1va/GM9FbpO9aZgsEu8Eq76QPxyR8nRqygyMRSuQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.8.tgz",
+      "integrity": "sha512-KqTsW2LViI1UjZTycfI0x3m+yZqV8zfIm/CiDAmtujUPAu8sU78jzByc8ke7FaFC6waDsfAKTKu4fBqSu7aH1w==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.7.tgz",
-      "integrity": "sha512-WVAc31MDgHTvP0dJNWsvLVJhjeVGZ3NrLpHcH9iIAd6HVO5Z+i+fk4zvodD+Y7jWU0psx8ZD8xe1wy8ECfbCBA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.8.tgz",
+      "integrity": "sha512-qarv4kXSrtroJy5dbmF0Vld7L8teeQxsV5N1g1Fjhi4uUCb43ioR9euBHIjju33kOLDYYXXw6L78XIe/cW6nIw==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.7.tgz",
-      "integrity": "sha512-LWXgxyMgBAldHA6Swx0irAISCMEyDEcZV7YxBoBpSDnV8ybtZP4fSgtj6vlpnrttKcnXFEcGokOuC3vSdEs39g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.8.tgz",
+      "integrity": "sha512-jJVAc/y7Mo/DLw8n14A1AFmhQe8rw5d+vCg/1k4hw0Oru4l2QU/8AA940kPeuky4Sj0hMLf9UWAS6A3gOo5ZTA==",
       "dependencies": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.7.tgz",
-      "integrity": "sha512-ZEXiJwPtuPeWa0QmRODF5qK0+ugZu/xeq7QxCvFOCc3NFVBeGms4g92HPucOju9R7jcODIoJxtICALsuwLAr9w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.8.tgz",
+      "integrity": "sha512-WoVi8btR0X2/fXJgt/oRy2gm32ECnibqUkxl0MOcLuxg7cHDZKFA5PwNK/eIx5hZZ2xM/ztoPtEohWV6LqLryw==",
       "dependencies": {
-        "@pixi/settings": "5.3.7"
+        "@pixi/settings": "5.3.8"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.7.tgz",
-      "integrity": "sha512-f8zAeHHURxfwBr8MZiXEIwY2h9wbS6vN0ypvapGvKFOexZ1EInTs35FhEiRWzLEPLHyn1RgCdKzR2zl++E4tIw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.8.tgz",
+      "integrity": "sha512-LljIFFOFcXLyLzXqIYwcXUqz6NsAUbwxb7Som9Gm3i1usGIqPRX4R08Iaf4L6OKA7417gSrRmbYdT0Hje/0ikA==",
       "dependencies": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/settings": "5.3.7",
+        "@pixi/constants": "5.3.8",
+        "@pixi/settings": "5.3.8",
         "earcut": "^2.1.5",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
@@ -1057,9 +1106,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "node_modules/@types/node": {
-      "version": "12.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+      "version": "13.13.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
+      "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1122,6 +1171,15 @@
         }
       ]
     },
+    "node_modules/big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
@@ -1130,10 +1188,48 @@
         "node": "*"
       }
     },
+    "node_modules/bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.7"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001191",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
+      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -1162,6 +1258,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -1199,6 +1301,20 @@
         }
       }
     },
+    "node_modules/default-browser-id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-2.0.0.tgz",
+      "integrity": "sha1-AezONxpx6F8VoXF354YwR+c9vn0=",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.1.0",
+        "pify": "^2.3.0",
+        "untildify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dom-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
@@ -1220,19 +1336,34 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.673",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz",
+      "integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==",
+      "dev": true
+    },
     "node_modules/es6-promise-polyfill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
       "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
     },
     "node_modules/esbuild": {
-      "version": "0.8.36",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.36.tgz",
-      "integrity": "sha512-kcUQB61Tf8rLJ3mOwP2ruWi/iFufaQcEs4No+JA6e7W2kMOtFExOsbyeFpEF6zNacwk2RF5fYUz5jfZwgn/SJg==",
+      "version": "0.8.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.51.tgz",
+      "integrity": "sha512-MVIom8fgL1+B6iGqWtrG7QJ1gqd64BycxounlsX1kR/IcIITaSlTo7gghKpg4a+bnxkpo0dwcikuvk4MVSA9ww==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1279,23 +1410,23 @@
       }
     },
     "node_modules/firebase": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.4.tgz",
-      "integrity": "sha512-+skMZY0kXKCFVAlbwoKnRDfOhmg9rp2lDZBJk/h4PYxh/joPNTXYCKFYqUkXfwSW4jQBlLP+PtjrZKeedg6mdA==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.9.tgz",
+      "integrity": "sha512-0QNPgKre9OHuBHwXKIs1wW1aPrO0wx1si3JMA46vPOmx/vkpQQD2OCxdZdVUc+y5u9d/yNMvVBR6j85H0O15rA==",
       "dependencies": {
-        "@firebase/analytics": "0.6.2",
-        "@firebase/app": "0.6.13",
+        "@firebase/analytics": "0.6.4",
+        "@firebase/app": "0.6.15",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.16.2",
-        "@firebase/database": "0.9.0",
-        "@firebase/firestore": "2.1.3",
-        "@firebase/functions": "0.6.1",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging": "0.7.3",
-        "@firebase/performance": "0.4.5",
+        "@firebase/auth": "0.16.4",
+        "@firebase/database": "0.9.4",
+        "@firebase/firestore": "2.1.7",
+        "@firebase/functions": "0.6.2",
+        "@firebase/installations": "0.4.20",
+        "@firebase/messaging": "0.7.4",
+        "@firebase/performance": "0.4.6",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.30",
-        "@firebase/storage": "0.4.2",
+        "@firebase/remote-config": "0.1.31",
+        "@firebase/storage": "0.4.3",
         "@firebase/util": "0.3.4"
       },
       "engines": {
@@ -1303,9 +1434,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -1315,6 +1446,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/gaxios": {
       "version": "4.1.0",
@@ -1362,9 +1499,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.5.tgz",
-      "integrity": "sha512-vlizrMSlHIu6blPtSC9AJZ1xYQWqUp1xqhcMzYff+hNKTSqVlsynMQIE8BdCo/FhPib4U1fvv1gnczMDHB2Wmg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
       "dependencies": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -1395,17 +1532,28 @@
       }
     },
     "node_modules/gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "dependencies": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "jws": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/has-flag": {
@@ -1438,6 +1586,18 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
       "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-docker": {
       "version": "2.1.1",
@@ -1506,9 +1666,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
@@ -1553,9 +1713,9 @@
       "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.camelcase": {
@@ -1577,17 +1737,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/mini-signals": {
@@ -1622,6 +1771,12 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1631,9 +1786,9 @@
       }
     },
     "node_modules/open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -1646,6 +1801,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-uri": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
@@ -1654,45 +1818,60 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pixi.js": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.7.tgz",
-      "integrity": "sha512-DyFTn6sHB6njtBd879OCx7UZpt8dpVtOSNuLAdVaWZ2GhAFsTY59n07Ol0f+zx07QtpCmSt1P3pXGHjt9sPzbw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.8.tgz",
+      "integrity": "sha512-kDqkWhuAkc42lD+ldVTaS439q7D7uo9FM/wCP26jUNAFlYAp75IcALEgXuBh6HEjp51enGkRvwX9+fIiA5F9ug==",
       "dependencies": {
-        "@pixi/accessibility": "5.3.7",
-        "@pixi/app": "5.3.7",
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/extract": "5.3.7",
-        "@pixi/filter-alpha": "5.3.7",
-        "@pixi/filter-blur": "5.3.7",
-        "@pixi/filter-color-matrix": "5.3.7",
-        "@pixi/filter-displacement": "5.3.7",
-        "@pixi/filter-fxaa": "5.3.7",
-        "@pixi/filter-noise": "5.3.7",
-        "@pixi/graphics": "5.3.7",
-        "@pixi/interaction": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/mesh-extras": "5.3.7",
-        "@pixi/mixin-cache-as-bitmap": "5.3.7",
-        "@pixi/mixin-get-child-by-name": "5.3.7",
-        "@pixi/mixin-get-global-position": "5.3.7",
-        "@pixi/particles": "5.3.7",
-        "@pixi/polyfill": "5.3.7",
-        "@pixi/prepare": "5.3.7",
-        "@pixi/runner": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/sprite-animated": "5.3.7",
-        "@pixi/sprite-tiling": "5.3.7",
-        "@pixi/spritesheet": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/text-bitmap": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/accessibility": "5.3.8",
+        "@pixi/app": "5.3.8",
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/extract": "5.3.8",
+        "@pixi/filter-alpha": "5.3.8",
+        "@pixi/filter-blur": "5.3.8",
+        "@pixi/filter-color-matrix": "5.3.8",
+        "@pixi/filter-displacement": "5.3.8",
+        "@pixi/filter-fxaa": "5.3.8",
+        "@pixi/filter-noise": "5.3.8",
+        "@pixi/graphics": "5.3.8",
+        "@pixi/interaction": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/mesh-extras": "5.3.8",
+        "@pixi/mixin-cache-as-bitmap": "5.3.8",
+        "@pixi/mixin-get-child-by-name": "5.3.8",
+        "@pixi/mixin-get-global-position": "5.3.8",
+        "@pixi/particles": "5.3.8",
+        "@pixi/polyfill": "5.3.8",
+        "@pixi/prepare": "5.3.8",
+        "@pixi/runner": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/sprite-animated": "5.3.8",
+        "@pixi/sprite-tiling": "5.3.8",
+        "@pixi/spritesheet": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/text-bitmap": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       },
       "funding": {
         "type": "opencollective",
@@ -1741,11 +1920,6 @@
         "pbts": "bin/pbts"
       }
     },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "13.13.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.40.tgz",
-      "integrity": "sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ=="
-    },
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -1759,6 +1933,19 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resource-loader": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
@@ -1769,13 +1956,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.0.tgz",
-      "integrity": "sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==",
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
+      "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.1.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -1783,22 +1967,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
-      }
-    },
-    "node_modules/rollup/node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "fsevents": "~2.3.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -1807,23 +1976,24 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/snowpack": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.11.tgz",
-      "integrity": "sha512-lBxgkvWTgdg0szE31JUt01wQkA9Lnmm+6lxqeV9rxDfflpx7ASnldVHFvu7Se70QJmPTQB0UJjfKI+xmYGwiiQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.13.tgz",
+      "integrity": "sha512-USTcpfJ68rbuFvUygw+3n9qS1CC/tGsr/JNVc6FNk0ZRfGBE4OmB+Mmk5nWtdxi546GeCr/GvveJenYLen/WpA==",
       "dev": true,
       "dependencies": {
+        "default-browser-id": "^2.0.0",
         "esbuild": "^0.8.7",
-        "fsevents": "^2.2.0",
         "open": "^7.0.4",
+        "resolve": "^1.20.0",
         "rollup": "^2.34.0"
       },
       "bin": {
@@ -1872,6 +2042,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -1908,9 +2090,9 @@
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "node_modules/workerpool": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.4.tgz",
-      "integrity": "sha512-sAc9w9oAJQ2680gDArGinjw0Ygj2K3KF1ZCRfslBKUCzc9Gycwlj9ZIAbizPRBftcXxhXgoGMVPxJE0VMNnWbw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
       "dev": true
     },
     "node_modules/xmlhttprequest": {
@@ -1929,159 +2111,178 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.12.13"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.13.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
+      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "dev": true
+    },
     "@babel/core": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
-      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
+      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.10",
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.10",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.0",
+        "@babel/parser": "^7.13.0",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "^5.4.1",
+        "semver": "7.0.0",
         "source-map": "^0.5.0"
       }
     },
     "@babel/generator": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
+      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.11",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
-      "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+    "@babel/helper-compilation-targets": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
+      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-member-expression-to-functions": "^7.12.1",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.10.4"
+        "@babel/compat-data": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "7.0.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.0.tgz",
+      "integrity": "sha512-twwzhthM4/+6o9766AW2ZBHpIHPSGrPGk1+WfHiu13u/lBnggXGNYCpeAyVfNwGDKfkhEDp+WOD/xafoJ2iLjA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-split-export-declaration": "^7.12.13"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
-      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.7"
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.5"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/helper-replace-supers": "^7.12.1",
-        "@babel/helper-simple-access": "^7.12.1",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
-      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
-      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.7",
-        "@babel/helper-optimise-call-expression": "^7.12.10",
-        "@babel/traverse": "^7.12.10",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.11"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -2090,96 +2291,102 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
+    "@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
     "@babel/helpers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
+      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
       "dev": true
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
-      "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
+      "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.12.tgz",
-      "integrity": "sha512-fhkE9lJYpw2mjHelBpM2zCbaA11aov2GJs7q4cFaXNrWx0H3bW58H9Esy2rdtYOghFBEYUDRIpvlgi+ZD+AvvQ==",
+      "version": "7.13.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.5.tgz",
+      "integrity": "sha512-i0GDfVNuoapwiheevUOuSW67mInqJ8qw7uWfpjNVeHMn143kXblEy/bmL9AdZ/0yf/4BMQeWXezK0tQIvNPqag==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-decorators": "^7.12.1"
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-decorators": "^7.12.13"
       }
     },
     "@babel/plugin-syntax-decorators": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
-      "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz",
+      "integrity": "sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/traverse": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.11",
-        "@babel/generator": "^7.12.11",
-        "@babel/helper-function-name": "^7.12.11",
-        "@babel/helper-split-export-declaration": "^7.12.11",
-        "@babel/parser": "^7.12.11",
-        "@babel/types": "^7.12.12",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -2188,13 +2395,13 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.4.tgz",
+      "integrity": "sha512-Lhnk5pXeDKoPf1b2cggWQaqCtNq+jn6IkhHMIo+7VztVt3i8ovnGuhAn/0hLC+XxvVWJ9q6CXIoGStkwvecDoA==",
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -2206,12 +2413,12 @@
       "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
-      "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.15.tgz",
+      "integrity": "sha512-VfULP09cci4xk+iAU6CB2CUNU/vbpAOoUleDdspXFphV9Yw36anb8RjaHGcN1DRR7LNb7vznNJXHk8FJhC8VWQ==",
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "dom-storage": "2.1.0",
@@ -2225,11 +2432,11 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.2.tgz",
-      "integrity": "sha512-68TlDL0yh3kF8PiCzI8m8RWd/bf/xCLUsdz1NZ2Dwea0sp6e2WAhu0sem1GfhwuEwL+Ns4jCdX7qbe/OQlkVEA==",
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.4.tgz",
+      "integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
       "requires": {
-        "@firebase/auth-types": "0.10.1"
+        "@firebase/auth-types": "0.10.2"
       }
     },
     "@firebase/auth-interop-types": {
@@ -2239,28 +2446,28 @@
       "requires": {}
     },
     "@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
+      "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
       "requires": {}
     },
     "@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.2.0.tgz",
+      "integrity": "sha512-QJJxMEzLRMWjujPBrrS32BScg1wmdY/dZWR8nAEzyC8WKQsNevYR9ZKLbBYxaN0umH9yf5C40kwmy+gI8jStPw==",
       "requires": {
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
       }
     },
     "@firebase/database": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.0.tgz",
-      "integrity": "sha512-j9NgRCsoahvAtQ8LPxMidGsiwsklbtUlDOQ6MhU6/Hk9DVYtEnVT3qSe42xOwBGDfMe191b1B2HsiEOsglWgag==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.4.tgz",
+      "integrity": "sha512-Fw2bA4OyxAMqLy8xtoZKlUAuDWjjH/z4AInRTAzHxgegXDbu0UK+VM0pmY44RuM2cmnVY4aW6xLXAdDKTY1aJQ==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
+        "@firebase/component": "0.2.0",
+        "@firebase/database-types": "0.7.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
         "faye-websocket": "0.11.3",
@@ -2268,19 +2475,19 @@
       }
     },
     "@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.0.tgz",
+      "integrity": "sha512-FduQmPpUUOHgbOt7/vWlC1ntSLMEqqYessdQ/ODd7RFWm53iVa0T1mpIDtNwqd8gW3k7cajjSjcLjfQGtvLGDg==",
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.3.tgz",
-      "integrity": "sha512-+No0hcaJ7hUYD/Vyv8xvEAnIqUQHJAFF5alL3clfyqmYa7bKtffjnZs2Pvm0fEIQ+LK4ovo2be2NmwK4iV0q5g==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.7.tgz",
+      "integrity": "sha512-sh+aX6udS8a+rwmlJO4zJwvoMC1D2x1CiPvj0nFYWhILRKWvztk/bOA3lT2FWcHY4kr/7x+CnqfwtiOSaufdNQ==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/firestore-types": "2.1.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.4",
@@ -2298,11 +2505,11 @@
       "requires": {}
     },
     "@firebase/functions": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.2.tgz",
+      "integrity": "sha512-f+NxRd0k5RBPZUPj8lykeNMku8TpJTgZaRd3T6cXb8HbmSg/VY7uxQSGOXe11X2gSv/TvcwTQttViFzRMDs7CQ==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
@@ -2315,11 +2522,11 @@
       "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.20.tgz",
+      "integrity": "sha512-ddUPZQKHWJzqg3g11hxHIPhp3oMEmsPo0GSxtp9Xd2VLRU64MFNAAt5PiBbq1K92ukZVoNh6Ki6J6+hJEQcGQw==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/installations-types": "0.3.4",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -2338,12 +2545,12 @@
       "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
     },
     "@firebase/messaging": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.4.tgz",
+      "integrity": "sha512-xIZ1vHnOcHAaj+H/gS8tu3QolR9up+fyTfgVLEFbZRsbAiLuIvuaoJwTHLAUTs/nJF6GtEGscRD4Jx/aFmEJRw==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/messaging-types": "0.5.0",
         "@firebase/util": "0.3.4",
         "idb": "3.0.2",
@@ -2357,12 +2564,12 @@
       "requires": {}
     },
     "@firebase/performance": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
-      "integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.6.tgz",
+      "integrity": "sha512-fy9YPYnvePFxme7euyi8B658gF8JUQhAB1qv6hVw+HqjVZQIANhwM9AUBi9+5jikD7gD1CnU7EjREvoy8MJiAw==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
         "@firebase/util": "0.3.4",
@@ -2385,12 +2592,12 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.31.tgz",
+      "integrity": "sha512-QWjDsrLSqQnq/YTb3TSOJtIv7z2GXB7mTiwXE43NxYmsOX2z8KBlBBEHf9TcWk+90MKUTFfurDgYJN4rlIOxPg==",
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.2.0",
+        "@firebase/installations": "0.4.20",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
         "@firebase/util": "0.3.4",
@@ -2403,11 +2610,11 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.3.tgz",
+      "integrity": "sha512-53IIt6Z3BltPBPmvxF/RGlvW8nBl4wI9GMR52CjRAIj438tPNxbpIvkLB956VVB9gfZhDcPIKxg7hNtC7hXrkA==",
       "requires": {
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.2.0",
         "@firebase/storage-types": "0.3.13",
         "@firebase/util": "0.3.4",
         "tslib": "^1.11.1"
@@ -2432,12 +2639,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
       "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
     },
-    "@grpc/grpc-js": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.5.tgz",
-      "integrity": "sha512-CBCNwedw8McnEBq9jvoiJikws16WN0OiHFejQPovY71XkFWSiIqgvydYiDwpvIYDJmhPQ7qZNzW9BPndhXbx1Q==",
+    "@gongfuio/hexgrid": {
+      "version": "file:../packages/hexgrid",
       "requires": {
-        "@types/node": "^12.12.47",
+        "prettier": "^2.2.1",
+        "snowpack": "^3.0.13"
+      }
+    },
+    "@grpc/grpc-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
+      "integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
+      "requires": {
+        "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
         "semver": "^6.2.0"
       },
@@ -2459,343 +2673,343 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.7.tgz",
-      "integrity": "sha512-104qzGZWnA/cQUH48jTiCXKGqOCfOqZAHmVg1z0p5l5tnzVX5zUQDBJxt4AAIPguZZe1YkniealwO1WGz0yBgA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.8.tgz",
+      "integrity": "sha512-DBkUUPIDfaw1hXFLTOsmZ401JSyu286rS2UB79ClxvVtDfGI7pR+Hgq1PuNeoQSiO9Db32W4grvuxYTulO2jkQ==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/app": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.7.tgz",
-      "integrity": "sha512-xlXxMGiGGmOA154SyltOQ2ZfPEtErzXl8GOxXJJJBxmIfvCQa+Y6iO5jf4q7yNbpSbrfaeIrYUnNbJAViiACzg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.8.tgz",
+      "integrity": "sha512-eekP/tIPlERZOiWOCVKgOCc66JoAHDP7yT9DBw2LtCKswvP83iwN0PX5YR/u6Z05kUW5y8t4bigfLqEqc4uChw==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8"
       }
     },
     "@pixi/constants": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.7.tgz",
-      "integrity": "sha512-MBcgIM/mSqonFezkCI9080IqNlc0wb8S9QJ5otBdseOWUQa/ua2jF7Jd1sCBGmi0IzS9/NOHFXzZVTdS7AC7Ow=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.8.tgz",
+      "integrity": "sha512-vTkgBgiox2pLj2ZK/X37O6rFjsLic6CYa+rSCCMo8lCwipG/dgizYoAVIsmZy30tFgg1xYzI6qOw3MSVXupp8Q=="
     },
     "@pixi/core": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.7.tgz",
-      "integrity": "sha512-WBhU2f5aJSVVaFP55FFBFKjKlRf5fYGxgA/U3kD4yD4Y3d3d6V3MIZv+o0VX+kBs1Eq7ePZqEv2smDrlzzMEjQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.8.tgz",
+      "integrity": "sha512-mbl7//UbNaIZJbS8R8g5o6cHAMW7xaJWW/dNazSJ9057Fpq5g3e3E2rreNTEILfC29cxm2sXDmgK5a9agoqJaA==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/runner": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/runner": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/display": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.7.tgz",
-      "integrity": "sha512-ma1JyLe5vaEgmaOR+anvj5YOKqT9OEWnboIe7NVmwGF1CZ7JFnB12rsRulHUsSaFG9bP5xjvroAZjFg/WvyGLw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.8.tgz",
+      "integrity": "sha512-ch7g63ox3iow/NEGbrArLfUMJVLVF+FpdFAp72uEweIzlcyzOQV6AcQTHtiRy4+tM6LdlcLSJXJISqGKt2R0Dg==",
       "requires": {
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/extract": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.7.tgz",
-      "integrity": "sha512-xQ5hYFIdxQTjNWwtwsjIK0DjbGLlUl92rIj5yvNJFiJvRjZ8IfvtIaM5uwjhiY2U9q3fDLFgb8EiNfmdDc78xQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.8.tgz",
+      "integrity": "sha512-z09D+5qmGQilbBXhR3xlZCixkTb6+1bSo6jGsbQxpu3xaF0ogh1HB76SJ2Wi1vwba9Q/PMb6RlawdEAg+sRFMg==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/filter-alpha": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.7.tgz",
-      "integrity": "sha512-jkvbzmSCIPjCJMFNUocAxsZ7Cq3ssFwXnmXNYKYhJy01LxiyO/JbVDAxAD7Chyn5jbKsI21OV3UQaIJhFpXw7Q==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.8.tgz",
+      "integrity": "sha512-4vOmuWDLBiMbdQ2S3PmxzrzpPOrlzZVZ8iPEkQrBCYZ4dIuZY7NaV+9tneIK66dDfVI6OA8Ai304LH22nhC81Q==",
       "requires": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "@pixi/filter-blur": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.7.tgz",
-      "integrity": "sha512-xM+Zz2i2UCmY7oHBPlGaN2ImhCY4l/V8NFc8FNSUIHm8NXHJ4/VCQpXp9BFTjY1+GZExFLkqB8kIYEddGVFiLA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.8.tgz",
+      "integrity": "sha512-biNqbfFIDbvOJJ+NiE9G0XojnuMQqtbcaDIiOScRoY3o3yCMjjcUxUMYrZ4xnTGGtEH23OKGUTZVf53qTQ4wiw==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/settings": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/settings": "5.3.8"
       }
     },
     "@pixi/filter-color-matrix": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.7.tgz",
-      "integrity": "sha512-Z12cxoHx9uMh3CZ0PLVRzsaFHHF/CfU3J83KI9k+Bg/DFOh/J/5EToCd44jYJbMKp3nvXcO1EJyZ3wwC/IsyfQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.8.tgz",
+      "integrity": "sha512-0Ag08uPKVoHWQSAIhS27Bs/b50NVMZ+3fUdNg9jgyrRthD/Uc2ljfkIJRa95Mj31YJBS15Giu4BGfefpe1i3zw==",
       "requires": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "@pixi/filter-displacement": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.7.tgz",
-      "integrity": "sha512-akMVkAHqliQujveiJ5KBMuwh/JVGN37NQsD8n1XbDDSe6SKjpX0kaq2Bh2Xu9pPj3+Jhofy0sI65q2M8qs2Uog==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.8.tgz",
+      "integrity": "sha512-OQYBK3oOId8VZV7KRYYdt196EYsG0cjAmQQT7P3/IETLIP6Mba+Bd/GtyxGEIBHcb7R5DebuvN4sVQtNgkRKlw==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8"
       }
     },
     "@pixi/filter-fxaa": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.7.tgz",
-      "integrity": "sha512-NJpVcbOCUVYUDGqxvh7Jp/+arWEnLKgI/7Qf8VEYv0aQslqE8ZtFSAX7JfP+iGfFWXlkMe6AKspesYhUrIpRKg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.8.tgz",
+      "integrity": "sha512-eOfrp46AEjkAM1U+6k9Ga/5ezEwr1+7yGS3VijZBHntZTYKFhmGGOXrQxxL4KuslrfTV/smAflEr22U+A2H98A==",
       "requires": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "@pixi/filter-noise": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.7.tgz",
-      "integrity": "sha512-P0mVQR2J7GHujVcq0iiuD2/1yvmue7orpppa5iuNHoOMT+vZpO0hdCKTg5vm5ZcWnHrOwtvv8zYngnT9rLdCtw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.8.tgz",
+      "integrity": "sha512-+MOz3GpB9XpH7d0B/HAz8zOp164UMKnE64Q9QI094X4KjXWj24RKZea8xFcOaOy9xKi57qqyo+3pLwqFB8ffsw==",
       "requires": {
-        "@pixi/core": "5.3.7"
+        "@pixi/core": "5.3.8"
       }
     },
     "@pixi/graphics": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.7.tgz",
-      "integrity": "sha512-+6+bT/AC29a1Hw5XDxsH1UqBsXSqcna7wNTTrBQ02owotIJtyRc6w48f5qxzhxycumyVCR87IV5tAtdwX3xhag==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.8.tgz",
+      "integrity": "sha512-auqwS6ZnDlNoerddLCoMpEzgq0o09WHH7XxwfTK75hJwBaFX1RO/nasfvCx2wAtWZxAYCaABfR8WnWZfrsBSqA==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/interaction": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.7.tgz",
-      "integrity": "sha512-B+5suog6fo8tJclTIO1Nn0HikyXQ9OWQGmTiYUnDVDriX5dGujh79RpcL51HFQ/2Gs2Gt0rl3AfP9OsCLe7VPA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.8.tgz",
+      "integrity": "sha512-i9KS9TNVK/PEwyjZH2iqui9xroy0R48u/QL4Q8+VQpwbeDlz+WlPWoW5R7rpUwtHd9H6mLWpGR3sdWOmS7fMsA==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/loaders": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.7.tgz",
-      "integrity": "sha512-zwWgvhUz7l5Z3me5gT1XbJzmj4bnz176PnawoUdlRxNARnMW3Rsk7Egzu8atWhJUL+MWEv+t8KkyHRXG39q5FA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.8.tgz",
+      "integrity": "sha512-0M2e/gkBBqJW695wz9DcsYN7IY992FKqb9uOEhFFjCn2bkK9WsR6M/JBvTlTk4LOvEg81b1/J51bkucpXWx1Cg==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/utils": "5.3.7",
+        "@pixi/core": "5.3.8",
+        "@pixi/utils": "5.3.8",
         "resource-loader": "^3.0.1"
       }
     },
     "@pixi/math": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.7.tgz",
-      "integrity": "sha512-WnjUwX7rkxR36F0xknpsNd9BsfQosV0BbyFE0Il88IURBM3Tu9X4tC7RGJDgWU+aXw23HgHu0j+MWJrCVCM2fA=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.8.tgz",
+      "integrity": "sha512-MZekzC9W391KU2NyzbRHrgYfjPKguzU5cRLbaEw9dgDabLh3/Yzob1KVg8dngIITPbi5yBmoX7zh7ZHEA1NRPQ=="
     },
     "@pixi/mesh": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.7.tgz",
-      "integrity": "sha512-7K5Ba3+t0rBAfZeuQi7nem0DgVH9GNhRvZ8HYbhPs5XVI7yZZhUN4HpUMy7gYEnz8EbXqwUz20X4ham/0O9WsQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.8.tgz",
+      "integrity": "sha512-/CQdTypiLgSZqKx9z89cJlLQ8/FaUrc8M3HjmL8Vy5F320ERCR1YLDc6gOzyohK71wDxkUud5VbNz5woQVSBxw==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/mesh-extras": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.7.tgz",
-      "integrity": "sha512-txVo2yk935gLgvlwO/ODUuz0wHUZtc9AK0sOQbbD9rh1TUdZ9OYrRvqshItLC34EimmAfgOsyzT78zeUTaP1OA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.8.tgz",
+      "integrity": "sha512-+lHcmvslKsmlixiJW87/t5diRy7p+tvqQbXMG4/3Vzv3dBEGq453hMIknlLr2xLGyzBtboCHObzwKfeE4tvHTw==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.7.tgz",
-      "integrity": "sha512-UEP1PVEEqgWs8vUx/GvOiQ4r130NDLQoD9i5YA1i5BGml2UmNyrFlIh8N9hVAPiIpTIpECkU6nLakP7t6fm9zA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.8.tgz",
+      "integrity": "sha512-Y4z3yvMldRUU99I+FBOl+j+TCq7CXN2ysNED/vMD2YpfilS2/8dQcAqRNEOBXCdSixd6+QHBuc0+PWR6M7irKg==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.7.tgz",
-      "integrity": "sha512-KiWirq5HpLKrAsShdZx0+RwNwY6nO5cM+Wqq59n11xTgvUoNULiptZRePQR5rOIsLIcwNtro/2LWPj1UzbJHbg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.8.tgz",
+      "integrity": "sha512-6Z4C2SucwC1w2xa260VxU+uIkP8FhwnZWDfY0rxyxecWxvkM7ULsIU9szoUYUJvLJnpxRi4Xb6rXNPxXyzis9Q==",
       "requires": {
-        "@pixi/display": "5.3.7"
+        "@pixi/display": "5.3.8"
       }
     },
     "@pixi/mixin-get-global-position": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.7.tgz",
-      "integrity": "sha512-OIXi+m611GVH1dVAc5YdiMC55Bbjf0JmesiB+6/gMzrjKxW/YDAA5ZRVri75hmRedHA8LPflf+i0pO10mrGP8g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.8.tgz",
+      "integrity": "sha512-o2ZKmTxDvoibGBZ8LP3qJZ3cHe7L447qsuHPPLYOPmA5hqG49YchwmKMwV6tn96C8yDECaVn429Hu5hZEI7UlA==",
       "requires": {
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7"
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8"
       }
     },
     "@pixi/particles": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.7.tgz",
-      "integrity": "sha512-mEnBljvBVbKuUJVZ0oH9dP/k7qsHEHUlvfBQgLOSkd6viHlx3PoSPKOYm35+I6fAylkV0Xm9+j5v/IESuip2RQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.8.tgz",
+      "integrity": "sha512-XAehJJ9SsLwlZF1Qkkir0ejPZ0YgCg8MbxzmrxBUbhH1NyHJLFm+K2S7Bp12FdR/hZwTENF7GMGVRH+o86u3hw==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/polyfill": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.7.tgz",
-      "integrity": "sha512-qU23xdb/e4Qvze0TWVy4fNZ0nlABIEZmuLu5nI9SpgfIYtjd2tZo7ngCXU5mZHxW1/xvkAMJEHCsSszotzF9xQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.8.tgz",
+      "integrity": "sha512-AIXfAjYD7dfP2C+TX3482YterwGE876amqmk6EzMZCI3vvsvDJUGT/Dx6lSOU5zbcUbJ9t3Ybz81xQYpaEhv/Q==",
       "requires": {
         "es6-promise-polyfill": "^1.2.0",
         "object-assign": "^4.1.1"
       }
     },
     "@pixi/prepare": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.7.tgz",
-      "integrity": "sha512-saU+o202vA3U2HVMYvh5aB2RJmP4hR//J22QuRfGen/ukM5mApOroJ445Id2+kSvis0M+UeFUKfBGWDzitr19Q==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.8.tgz",
+      "integrity": "sha512-DbYxQdziypsdQJaRKwdmODkIy2mQHETEFlVWou0XwVy+WB8VBlSnHZ57cVEY8l6Z0hJ93Vo4K6j5qIRi9MRjJA==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/graphics": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/ticker": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/graphics": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/ticker": "5.3.8"
       }
     },
     "@pixi/runner": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.7.tgz",
-      "integrity": "sha512-kt5apNb21HAvpBaDaPRs33k2O0VzrKe13w4we8iftCpXX8w68ErAY1lH68vmtDNrxnlHg4M9nRgEoMeiHlo2RA=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.8.tgz",
+      "integrity": "sha512-6Y9v9OHd5FFv6s0M4AGHnG3qvLiTBM5T5RnlEqMNMsqH6CWSDq0mNJA5HQD65q5ViK8HM6MYPm2nwwkYq5AICQ=="
     },
     "@pixi/settings": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.7.tgz",
-      "integrity": "sha512-g6AoRSGWxU34gtKSQwX2AMQoLUv86L/5iIXRsqo+X4bfUSCenTci1X7ueVrSIbo39dxh6IOpriZF2Yk3TeHG5w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.8.tgz",
+      "integrity": "sha512-/NSd9v6+IbG3GjzIoNwy7rgPg6kwwWy54pcaiM3Wv3zjkwhkVySK4m3h892Wa2z5lFvrHEH9zewGJwEpUH/FMA==",
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.7.tgz",
-      "integrity": "sha512-Bjl+NOOvigEzUsm1cDr1KmBUpPSWO8pDXpUPTi+v2N75gwRfTycmj5f2TU0QmMW3Gc6sv0CB0AkL7dkMPwPb8g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.8.tgz",
+      "integrity": "sha512-r+WeX5cti3VKu6U+hZeSiY4UC8912FjNU7M5bA/gev9CfUKv3fNwKYshPfzOkTPua8dFwI1U6tplYu5rSPMBmw==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/sprite-animated": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.7.tgz",
-      "integrity": "sha512-CSXTSwH/UUcTe5637AD35OCETQO+tDkmlr6e1/eIyUlgOsPkbjo+l134feLZtZudiPHTPyb/YAYIlgPfVr7MGw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.8.tgz",
+      "integrity": "sha512-zLnzmCJJ++Hyyy1LPh5Lt4icPuy8C+vL59yVj3nAYzqq/G26rFuHELexB0iwKBPE9yQYuaUQhFgOPgW4vFqLAw==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/ticker": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/ticker": "5.3.8"
       }
     },
     "@pixi/sprite-tiling": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.7.tgz",
-      "integrity": "sha512-0BMLQGniJF1HvfyrJVe5jC8ayBpTh19dAHJIQWGp8zxxFh/WHjR1b32BN74rDjxQQSjZjV8vBNio8J3W+yDttw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.8.tgz",
+      "integrity": "sha512-SvCAvajihsaNx/xX4s6waEqPLVkI5W86h31kpoqdPj3zXhoLbpZh6t2TWbcRJmgjM1GvBNy14gWtelBq8UF7Mg==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/spritesheet": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.7.tgz",
-      "integrity": "sha512-K1Befbrq3LDbFtnLmbk54QQ/YRk2Mgd+2iOkZx5KsS2pTh1va/GM9FbpO9aZgsEu8Eq76QPxyR8nRqygyMRSuQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.8.tgz",
+      "integrity": "sha512-KqTsW2LViI1UjZTycfI0x3m+yZqV8zfIm/CiDAmtujUPAu8sU78jzByc8ke7FaFC6waDsfAKTKu4fBqSu7aH1w==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/text": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.7.tgz",
-      "integrity": "sha512-WVAc31MDgHTvP0dJNWsvLVJhjeVGZ3NrLpHcH9iIAd6HVO5Z+i+fk4zvodD+Y7jWU0psx8ZD8xe1wy8ECfbCBA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.8.tgz",
+      "integrity": "sha512-qarv4kXSrtroJy5dbmF0Vld7L8teeQxsV5N1g1Fjhi4uUCb43ioR9euBHIjju33kOLDYYXXw6L78XIe/cW6nIw==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/text-bitmap": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.7.tgz",
-      "integrity": "sha512-LWXgxyMgBAldHA6Swx0irAISCMEyDEcZV7YxBoBpSDnV8ybtZP4fSgtj6vlpnrttKcnXFEcGokOuC3vSdEs39g==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.8.tgz",
+      "integrity": "sha512-jJVAc/y7Mo/DLw8n14A1AFmhQe8rw5d+vCg/1k4hw0Oru4l2QU/8AA940kPeuky4Sj0hMLf9UWAS6A3gOo5ZTA==",
       "requires": {
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "@pixi/ticker": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.7.tgz",
-      "integrity": "sha512-ZEXiJwPtuPeWa0QmRODF5qK0+ugZu/xeq7QxCvFOCc3NFVBeGms4g92HPucOju9R7jcODIoJxtICALsuwLAr9w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.8.tgz",
+      "integrity": "sha512-WoVi8btR0X2/fXJgt/oRy2gm32ECnibqUkxl0MOcLuxg7cHDZKFA5PwNK/eIx5hZZ2xM/ztoPtEohWV6LqLryw==",
       "requires": {
-        "@pixi/settings": "5.3.7"
+        "@pixi/settings": "5.3.8"
       }
     },
     "@pixi/utils": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.7.tgz",
-      "integrity": "sha512-f8zAeHHURxfwBr8MZiXEIwY2h9wbS6vN0ypvapGvKFOexZ1EInTs35FhEiRWzLEPLHyn1RgCdKzR2zl++E4tIw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.8.tgz",
+      "integrity": "sha512-LljIFFOFcXLyLzXqIYwcXUqz6NsAUbwxb7Som9Gm3i1usGIqPRX4R08Iaf4L6OKA7417gSrRmbYdT0Hje/0ikA==",
       "requires": {
-        "@pixi/constants": "5.3.7",
-        "@pixi/settings": "5.3.7",
+        "@pixi/constants": "5.3.8",
+        "@pixi/settings": "5.3.8",
         "earcut": "^2.1.5",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
@@ -2871,9 +3085,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "12.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+      "version": "13.13.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
+      "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -2910,15 +3124,49 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true
+    },
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.7"
+      }
+    },
+    "browserslist": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001191",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
+      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -2946,6 +3194,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -2968,6 +3222,17 @@
         "ms": "2.1.2"
       }
     },
+    "default-browser-id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-2.0.0.tgz",
+      "integrity": "sha1-AezONxpx6F8VoXF354YwR+c9vn0=",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.1.0",
+        "pify": "^2.3.0",
+        "untildify": "^2.0.0"
+      }
+    },
     "dom-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
@@ -2986,15 +3251,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.673",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz",
+      "integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==",
+      "dev": true
+    },
     "es6-promise-polyfill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
       "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
     },
     "esbuild": {
-      "version": "0.8.36",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.36.tgz",
-      "integrity": "sha512-kcUQB61Tf8rLJ3mOwP2ruWi/iFufaQcEs4No+JA6e7W2kMOtFExOsbyeFpEF6zNacwk2RF5fYUz5jfZwgn/SJg==",
+      "version": "0.8.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.51.tgz",
+      "integrity": "sha512-MVIom8fgL1+B6iGqWtrG7QJ1gqd64BycxounlsX1kR/IcIITaSlTo7gghKpg4a+bnxkpo0dwcikuvk4MVSA9ww==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -3032,32 +3309,38 @@
       }
     },
     "firebase": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.4.tgz",
-      "integrity": "sha512-+skMZY0kXKCFVAlbwoKnRDfOhmg9rp2lDZBJk/h4PYxh/joPNTXYCKFYqUkXfwSW4jQBlLP+PtjrZKeedg6mdA==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.9.tgz",
+      "integrity": "sha512-0QNPgKre9OHuBHwXKIs1wW1aPrO0wx1si3JMA46vPOmx/vkpQQD2OCxdZdVUc+y5u9d/yNMvVBR6j85H0O15rA==",
       "requires": {
-        "@firebase/analytics": "0.6.2",
-        "@firebase/app": "0.6.13",
+        "@firebase/analytics": "0.6.4",
+        "@firebase/app": "0.6.15",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.16.2",
-        "@firebase/database": "0.9.0",
-        "@firebase/firestore": "2.1.3",
-        "@firebase/functions": "0.6.1",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging": "0.7.3",
-        "@firebase/performance": "0.4.5",
+        "@firebase/auth": "0.16.4",
+        "@firebase/database": "0.9.4",
+        "@firebase/firestore": "2.1.7",
+        "@firebase/functions": "0.6.2",
+        "@firebase/installations": "0.4.20",
+        "@firebase/messaging": "0.7.4",
+        "@firebase/performance": "0.4.6",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.30",
-        "@firebase/storage": "0.4.2",
+        "@firebase/remote-config": "0.1.31",
+        "@firebase/storage": "0.4.3",
         "@firebase/util": "0.3.4"
       }
     },
     "fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gaxios": {
       "version": "4.1.0",
@@ -3093,9 +3376,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.5.tgz",
-      "integrity": "sha512-vlizrMSlHIu6blPtSC9AJZ1xYQWqUp1xqhcMzYff+hNKTSqVlsynMQIE8BdCo/FhPib4U1fvv1gnczMDHB2Wmg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -3117,14 +3400,22 @@
       }
     },
     "gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "jws": "^4.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -3151,6 +3442,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
       "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-docker": {
       "version": "2.1.1",
@@ -3198,9 +3498,9 @@
       }
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -3239,9 +3539,9 @@
       "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -3261,11 +3561,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "mime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
     },
     "mini-signals": {
       "version": "1.2.0",
@@ -3293,65 +3588,89 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
+    "node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "parse-uri": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
       "integrity": "sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA=="
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
     "pixi.js": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.7.tgz",
-      "integrity": "sha512-DyFTn6sHB6njtBd879OCx7UZpt8dpVtOSNuLAdVaWZ2GhAFsTY59n07Ol0f+zx07QtpCmSt1P3pXGHjt9sPzbw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.8.tgz",
+      "integrity": "sha512-kDqkWhuAkc42lD+ldVTaS439q7D7uo9FM/wCP26jUNAFlYAp75IcALEgXuBh6HEjp51enGkRvwX9+fIiA5F9ug==",
       "requires": {
-        "@pixi/accessibility": "5.3.7",
-        "@pixi/app": "5.3.7",
-        "@pixi/constants": "5.3.7",
-        "@pixi/core": "5.3.7",
-        "@pixi/display": "5.3.7",
-        "@pixi/extract": "5.3.7",
-        "@pixi/filter-alpha": "5.3.7",
-        "@pixi/filter-blur": "5.3.7",
-        "@pixi/filter-color-matrix": "5.3.7",
-        "@pixi/filter-displacement": "5.3.7",
-        "@pixi/filter-fxaa": "5.3.7",
-        "@pixi/filter-noise": "5.3.7",
-        "@pixi/graphics": "5.3.7",
-        "@pixi/interaction": "5.3.7",
-        "@pixi/loaders": "5.3.7",
-        "@pixi/math": "5.3.7",
-        "@pixi/mesh": "5.3.7",
-        "@pixi/mesh-extras": "5.3.7",
-        "@pixi/mixin-cache-as-bitmap": "5.3.7",
-        "@pixi/mixin-get-child-by-name": "5.3.7",
-        "@pixi/mixin-get-global-position": "5.3.7",
-        "@pixi/particles": "5.3.7",
-        "@pixi/polyfill": "5.3.7",
-        "@pixi/prepare": "5.3.7",
-        "@pixi/runner": "5.3.7",
-        "@pixi/settings": "5.3.7",
-        "@pixi/sprite": "5.3.7",
-        "@pixi/sprite-animated": "5.3.7",
-        "@pixi/sprite-tiling": "5.3.7",
-        "@pixi/spritesheet": "5.3.7",
-        "@pixi/text": "5.3.7",
-        "@pixi/text-bitmap": "5.3.7",
-        "@pixi/ticker": "5.3.7",
-        "@pixi/utils": "5.3.7"
+        "@pixi/accessibility": "5.3.8",
+        "@pixi/app": "5.3.8",
+        "@pixi/constants": "5.3.8",
+        "@pixi/core": "5.3.8",
+        "@pixi/display": "5.3.8",
+        "@pixi/extract": "5.3.8",
+        "@pixi/filter-alpha": "5.3.8",
+        "@pixi/filter-blur": "5.3.8",
+        "@pixi/filter-color-matrix": "5.3.8",
+        "@pixi/filter-displacement": "5.3.8",
+        "@pixi/filter-fxaa": "5.3.8",
+        "@pixi/filter-noise": "5.3.8",
+        "@pixi/graphics": "5.3.8",
+        "@pixi/interaction": "5.3.8",
+        "@pixi/loaders": "5.3.8",
+        "@pixi/math": "5.3.8",
+        "@pixi/mesh": "5.3.8",
+        "@pixi/mesh-extras": "5.3.8",
+        "@pixi/mixin-cache-as-bitmap": "5.3.8",
+        "@pixi/mixin-get-child-by-name": "5.3.8",
+        "@pixi/mixin-get-global-position": "5.3.8",
+        "@pixi/particles": "5.3.8",
+        "@pixi/polyfill": "5.3.8",
+        "@pixi/prepare": "5.3.8",
+        "@pixi/runner": "5.3.8",
+        "@pixi/settings": "5.3.8",
+        "@pixi/sprite": "5.3.8",
+        "@pixi/sprite-animated": "5.3.8",
+        "@pixi/sprite-tiling": "5.3.8",
+        "@pixi/spritesheet": "5.3.8",
+        "@pixi/text": "5.3.8",
+        "@pixi/text-bitmap": "5.3.8",
+        "@pixi/ticker": "5.3.8",
+        "@pixi/utils": "5.3.8"
       }
     },
     "prettier": {
@@ -3383,13 +3702,6 @@
         "@types/long": "^4.0.1",
         "@types/node": "^13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.40.tgz",
-          "integrity": "sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ=="
-        }
       }
     },
     "punycode": {
@@ -3402,6 +3714,16 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
     "resource-loader": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
@@ -3412,21 +3734,12 @@
       }
     },
     "rollup": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.0.tgz",
-      "integrity": "sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==",
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
+      "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "dev": true,
-          "optional": true
-        }
+        "fsevents": "~2.3.1"
       }
     },
     "safe-buffer": {
@@ -3435,20 +3748,22 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true
     },
     "snowpack": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.11.tgz",
-      "integrity": "sha512-lBxgkvWTgdg0szE31JUt01wQkA9Lnmm+6lxqeV9rxDfflpx7ASnldVHFvu7Se70QJmPTQB0UJjfKI+xmYGwiiQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/snowpack/-/snowpack-3.0.13.tgz",
+      "integrity": "sha512-USTcpfJ68rbuFvUygw+3n9qS1CC/tGsr/JNVc6FNk0ZRfGBE4OmB+Mmk5nWtdxi546GeCr/GvveJenYLen/WpA==",
       "dev": true,
       "requires": {
+        "default-browser-id": "^2.0.0",
         "esbuild": "^0.8.7",
         "fsevents": "^2.2.0",
         "open": "^7.0.4",
+        "resolve": "^1.20.0",
         "rollup": "^2.34.0"
       }
     },
@@ -3477,6 +3792,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
     },
     "url": {
       "version": "0.11.0",
@@ -3508,9 +3832,9 @@
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "workerpool": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.4.tgz",
-      "integrity": "sha512-sAc9w9oAJQ2680gDArGinjw0Ygj2K3KF1ZCRfslBKUCzc9Gycwlj9ZIAbizPRBftcXxhXgoGMVPxJE0VMNnWbw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
       "dev": true
     },
     "xmlhttprequest": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,17 +24,21 @@
     "test": "echo \"This package does not include a test runner.\" && exit 1"
   },
   "dependencies": {
+    "@gongfuio/hexgrid": "^0.1.0",
     "firebase": "^8.2.4",
     "lit-element": "^2.4.0",
     "pixi.js": "^5.3.7"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.12.1",
-    "@babel/plugin-proposal-decorators": "^7.12.12",
+    "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-proposal-decorators": "^7.13.5",
     "@snowpack/plugin-babel": "^2.1.6",
     "prettier": "^2.2.1",
-    "snowpack": "^3.0.11"
+    "snowpack": "^3.0.13"
   },
+  "workspaces": [
+    "../packages/*"
+  ],
   "engines": {
     "node": ">=14"
   },

--- a/webapp/snowpack.config.js
+++ b/webapp/snowpack.config.js
@@ -10,6 +10,6 @@ module.exports = {
   plugins: [ '@snowpack/plugin-babel' ],
   packageOptions: { polyfillNode: true },
   devOptions: { output: "stream" }, // add `secure: true` for HTTPS
-  buildOptions: { out: "build", metaUrlPath: "web_modules", sourcemap: true },
+  buildOptions: { out: "build", metaUrlPath: "modules", sourcemap: true },
   optimize: { minify: true, treeshake: true }
 };

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -13,7 +13,7 @@
     <link href="/styles.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=VT323&family=IBM+Plex+Sans:wght@700&display=swap" rel="stylesheet" />
     <link rel="preload" href="/components/app-game.js" as="script" />
-    <link rel="preload" href="/web_modules/pkg/pixijs.js" as="script" />
+    <link rel="preload" href="/modules/pkg/pixijs.js" as="script" />
   </head>
   <body>
     <header>


### PR DESCRIPTION
Resolves #18:

* Adds [‹Hexgrid› implementation from Red Blob Games](https://www.redblobgames.com/grids/hexagons/implementation.html) packaged as an ES module;
* Adds _monorepo_ layout with [NPM workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) for use of `@gongfuio/hexgrid` package in webapp.
